### PR TITLE
Fix build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
             <version>1.9.3</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>6.0.5.Final</version>
         </dependency>

--- a/src/main/java/net/media/openrtb25/request/Pmp.java
+++ b/src/main/java/net/media/openrtb25/request/Pmp.java
@@ -53,7 +53,7 @@ public class Pmp {
     return this.ext;
   }
 
-  public void setExt(Map ext) {
+  public void setExt(Map<String, Object> ext) {
     this.ext = ext;
   }
 


### PR DESCRIPTION
fix for 2 warning during build time

`[WARNING] openrtb-model/src/main/java/net/media/openrtb25/request/Pmp.java uses unchecked or unsafe operations.`

`[WARNING] The artifact org.hibernate:hibernate-validator:jar:6.0.5.Final has been relocated to org.hibernate.validator:hibernate-validator:jar:6.0.5.Final`